### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,6 +3,7 @@ import groovy.json.JsonSlurper
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
@@ -57,6 +58,7 @@ repositories {
     }
     mavenCentral()
     jcenter()
+    google()
 }
 
 dependencies {


### PR DESCRIPTION
add google() so that it can correctly build as `com.android.tools.build:gradle:3.0.1` is depending on this repo. This is related to the issue #1 